### PR TITLE
No more defaults for CurrentUserAccessor

### DIFF
--- a/src/main/kotlin/coverosR3z/authentication/AuthenticationUtilities.kt
+++ b/src/main/kotlin/coverosR3z/authentication/AuthenticationUtilities.kt
@@ -9,7 +9,7 @@ import coverosR3z.domainobjects.LoginStatuses.*
 import coverosR3z.logging.logInfo
 
 
-class AuthenticationUtilities(val ap : IAuthPersistence, private val cua : ICurrentUserAccessor = CurrentUserAccessor()){
+class AuthenticationUtilities(val ap : IAuthPersistence, private val cua : ICurrentUserAccessor){
 
     val blacklistedPasswords : List<String> = listOf<String>("password")
 

--- a/src/main/kotlin/coverosR3z/timerecording/TimeRecordingUtilities.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/TimeRecordingUtilities.kt
@@ -9,7 +9,7 @@ import coverosR3z.logging.logInfo
 import coverosR3z.persistence.ProjectIntegrityViolationException
 import coverosR3z.persistence.EmployeeIntegrityViolationException
 
-class TimeRecordingUtilities(private val persistence: ITimeEntryPersistence, private val cua : ICurrentUserAccessor = CurrentUserAccessor()) {
+class TimeRecordingUtilities(private val persistence: ITimeEntryPersistence, private val cua : ICurrentUserAccessor) {
 
     fun recordTime(entry: TimeEntryPreDatabase): RecordTimeResult {
         val user = cua.get()?: throw AssertionError("Cannot record time when no user is logged in."  +

--- a/src/test/kotlin/coverosR3z/TestHelpers.kt
+++ b/src/test/kotlin/coverosR3z/TestHelpers.kt
@@ -1,4 +1,5 @@
 package coverosR3z
+import coverosR3z.authentication.FakeCurrentUserAccessor
 import coverosR3z.domainobjects.*
 import coverosR3z.persistence.PureMemoryDatabase
 import coverosR3z.timerecording.ITimeEntryPersistence
@@ -69,5 +70,5 @@ val jsonSerialzationWithPrettyPrint : Json = Json{prettyPrint = true; allowStruc
  */
 fun createTimeRecordingUtility(): TimeRecordingUtilities {
         val timeEntryPersistence : ITimeEntryPersistence = TimeEntryPersistence(PureMemoryDatabase())
-        return TimeRecordingUtilities(timeEntryPersistence)
+        return TimeRecordingUtilities(timeEntryPersistence, FakeCurrentUserAccessor())
 }

--- a/src/test/kotlin/coverosR3z/authentication/AuthenticationUtilitiesTests.kt
+++ b/src/test/kotlin/coverosR3z/authentication/AuthenticationUtilitiesTests.kt
@@ -17,7 +17,7 @@ class AuthenticationUtilitiesTests {
     @Before
     fun init() {
         ap = FakeAuthPersistence()
-        authUtils = AuthenticationUtilities(ap)
+        authUtils = AuthenticationUtilities(ap, FakeCurrentUserAccessor())
     }
 
     @Test
@@ -98,7 +98,7 @@ class AuthenticationUtilitiesTests {
     @Test
     fun `Should determine if a particular username is for a registered user`() {
         ap = FakeAuthPersistence(isUserRegisteredBehavior = {true})
-        authUtils = AuthenticationUtilities(ap)
+        authUtils = AuthenticationUtilities(ap, FakeCurrentUserAccessor())
 
         val result = authUtils.isUserRegistered("jenna")
         assertEquals(true, result)
@@ -174,7 +174,7 @@ class AuthenticationUtilitiesTests {
         val fap = FakeAuthPersistence(
                 getUserBehavior= { User(1, "matt", Hash.createHash(wellSeasoned), salt, null) }
         )
-        val au = AuthenticationUtilities(fap)
+        val au = AuthenticationUtilities(fap, FakeCurrentUserAccessor())
         val (status, _) = au.login("matt", "wrong")
         assertEquals(FAILURE, status)
     }
@@ -188,7 +188,7 @@ class AuthenticationUtilitiesTests {
         val fap = FakeAuthPersistence(
                 getUserBehavior= { null }
         )
-        val au = AuthenticationUtilities(fap)
+        val au = AuthenticationUtilities(fap, FakeCurrentUserAccessor())
         val (status, _) = au.login("matt", "arbitrary")
         assertEquals(NOT_REGISTERED, status)
     }

--- a/src/test/kotlin/coverosR3z/timerecording/EnteringTimeBDD.kt
+++ b/src/test/kotlin/coverosR3z/timerecording/EnteringTimeBDD.kt
@@ -6,6 +6,7 @@ import coverosR3z.domainobjects.*
 import coverosR3z.exceptions.ExceededDailyHoursAmountException
 import coverosR3z.persistence.PureMemoryDatabase
 import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Test
 
 
@@ -19,7 +20,12 @@ import org.junit.Test
  */
 class EnteringTimeBDD {
 
-    val cua = CurrentUserAccessor()
+    val currentUserAccessor = CurrentUserAccessor()
+
+    @Before
+    fun init() {
+        currentUserAccessor.clearCurrentUserTestOnly()
+    }
 
     /**
      * Just a happy path for entering a time entry
@@ -85,10 +91,10 @@ class EnteringTimeBDD {
     }
 
     private fun `given the employee has already entered 24 hours of time entries before`(): Triple<TimeRecordingUtilities, Project, Employee> {
-        cua.clearCurrentUserTestOnly()
-        cua.set(User(1, "Zim", Hash.createHash(""), "", 1))
+        currentUserAccessor.clearCurrentUserTestOnly()
+        currentUserAccessor.set(User(1, "Zim", Hash.createHash(""), "", 1))
         val timeEntryPersistence : ITimeEntryPersistence = TimeEntryPersistence(PureMemoryDatabase())
-        val tru = TimeRecordingUtilities(timeEntryPersistence, cua)
+        val tru = TimeRecordingUtilities(timeEntryPersistence, currentUserAccessor)
         val newProject: Project = tru.createProject(ProjectName("A"))
         val newEmployee: Employee = tru.createEmployee(EmployeeName("B"))
         val existingTimeForTheDay = createTimeEntryPreDatabase(employee = newEmployee, project = newProject, time = Time(60 * 24))

--- a/src/test/kotlin/coverosR3z/timerecording/TimeRecordingTests.kt
+++ b/src/test/kotlin/coverosR3z/timerecording/TimeRecordingTests.kt
@@ -189,7 +189,7 @@ class TimeRecordingTests {
     @Test fun `can create project`() {
         val fakeTimeEntryPersistence = FakeTimeEntryPersistence(
                 persistNewProjectBehavior = { Project(1, "test project") })
-        val utils = TimeRecordingUtilities(fakeTimeEntryPersistence)
+        val utils = TimeRecordingUtilities(fakeTimeEntryPersistence, FakeCurrentUserAccessor())
         val expected = utils.createProject(ProjectName("test project"))
         val actual = Project(1, "test project")
         assertEquals(expected, actual)


### PR DESCRIPTION
Now when you want to use classes that require CurrentUserAccessor, you will need to set something, you cannot rely on a default value.

Some minor renamings

Now the BDD files that use currentUserAccesssor have an initialization that clears the current user.

Co-authored-by: Mitch Hardee <mitchell.hardee@coveros.com>
Co-authored-by: Byron Katz <byron.katz@coveros.com>
Co-authored-by: Matt Taylor <matthew.taylor@coveros.com>
Co-authored-by: Jona Qorri <jona.qorri@coveros.com>