### PR TITLE
refactor: Move a scenario from authentication to enter time

### DIFF
--- a/src/test/kotlin/coverosR3z/authentication/AuthenticationBDD.kt
+++ b/src/test/kotlin/coverosR3z/authentication/AuthenticationBDD.kt
@@ -27,19 +27,6 @@ class AuthenticationBDD {
     }
 
     @Test
-    fun `I can add a time entry`() {
-        // Given I am logged in
-        val (tru, _) = initializeAUserAndLogin()
-
-        // When I add a time entry
-        val entry = createTimeEntryPreDatabase(Employee(1, "Alice"))
-        val result = tru.recordTime(entry)
-
-        // Then it proceeds successfully
-        assertEquals(RecordTimeResult(StatusEnum.SUCCESS), result)
-    }
-
-    @Test
     fun `I cannot change someone else's time`() {
         // Given I am logged in as user "alice" and employees Sarah and Alice exist in the database
         val (tru, sarah) = initializeTwoUsersAndLogin()
@@ -137,30 +124,11 @@ class AuthenticationBDD {
     fun initializeTwoUsersAndLogin() : Pair<TimeRecordingUtilities, Employee>{
         // We need to use cua for this test, sharing a pmd with auth persistence
         // and time recording persistence, in order to avoid recordTime throwing a USER_EMPLOYEE_MISMATCH status
-        val (tru, _) = initializeAUserAndLogin()
+        val (tru, _) = initializeAUserAndLogin(currentUserAccessor)
         val sarah = tru.createEmployee(EmployeeName("Sarah")) // Sarah will have id=2
 
         return Pair(tru, sarah)
     }
 
-    fun initializeAUserAndLogin() : Pair<TimeRecordingUtilities, Employee>{
-        val pmd = PureMemoryDatabase()
-        val authPersistence = AuthenticationPersistence(pmd)
-        val au = AuthenticationUtilities(authPersistence, currentUserAccessor)
 
-        val tru = TimeRecordingUtilities(TimeEntryPersistence(pmd), currentUserAccessor)
-        val alice = tru.createEmployee(EmployeeName("Alice"))
-
-        au.register("alice", DEFAULT_PASSWORD, alice.id)
-        au.login("alice", DEFAULT_PASSWORD)
-
-        // Perform some quick checks
-        assertEquals("Auth persistence and user persistence must agree",
-                authPersistence.getUser(UserName("alice")), currentUserAccessor.get())
-        assertTrue("Registration must have succeeded", au.isUserRegistered("alice"))
-
-        tru.createProject(DEFAULT_PROJECT_NAME)
-
-        return Pair(tru, alice)
-    }
 }

--- a/src/test/kotlin/coverosR3z/timerecording/EnteringTimeBDD.kt
+++ b/src/test/kotlin/coverosR3z/timerecording/EnteringTimeBDD.kt
@@ -31,14 +31,16 @@ class EnteringTimeBDD {
      * Just a happy path for entering a time entry
      */
     @Test
-    fun `capability to enter time`() {
-        val (expectedStatus, tru, entry) = `given I have worked 1 hour on project "A" on Monday`()
+    fun `I can add a time entry`() {
+        // Given I am logged in
+        val (tru, _) = initializeAUserAndLogin(currentUserAccessor)
 
-        // when I enter in that time
-        val recordStatus = tru.recordTime(entry)
+        // When I add a time entry
+        val entry = createTimeEntryPreDatabase(Employee(1, "Alice"))
+        val result = tru.recordTime(entry)
 
-        // then the system indicates it has persisted the new information
-        assertEquals("the system indicates it has persisted the new information", expectedStatus, recordStatus)
+        // Then it proceeds successfully
+        assertEquals(RecordTimeResult(StatusEnum.SUCCESS), result)
     }
 
     /**
@@ -66,6 +68,14 @@ class EnteringTimeBDD {
         assertThrows(ExceededDailyHoursAmountException::class.java) { tru.recordTime(entry) }
     }
 
+    /*
+     _ _       _                  __ __        _    _           _
+    | | | ___ | | ___  ___  _ _  |  \  \ ___ _| |_ | |_  ___  _| | ___
+    |   |/ ._>| || . \/ ._>| '_> |     |/ ._> | |  | . |/ . \/ . |<_-<
+    |_|_|\___.|_||  _/\___.|_|   |_|_|_|\___. |_|  |_|_|\___/\___|/__/
+                 |_|
+     alt-text: Helper Methods
+     */
 
     private fun `given I have worked 1 hour on project "A" on Monday`(): Triple<RecordTimeResult, TimeRecordingUtilities, TimeEntryPreDatabase> {
         val expectedStatus = RecordTimeResult(StatusEnum.SUCCESS)
@@ -101,7 +111,5 @@ class EnteringTimeBDD {
         tru.recordTime(existingTimeForTheDay)
         return Triple(tru, newProject, newEmployee)
     }
-
-
 
 }


### PR DESCRIPTION
Refactoring a scenario

Seemed like entering time (happy path) should probably belong in just entering time.
Now that scenario is more fully-featured, less unit-test-like

Co-authored-by: Mitch Hardee <mitchell.hardee@coveros.com>
Co-authored-by: Byron Katz <byron.katz@coveros.com>
Co-authored-by: Matt Taylor <matthew.taylor@coveros.com>
Co-authored-by: Jona Qorri <jona.qorri@coveros.com>