### PR TITLE
Refactor EnterTimeAPI to the correct location, and begin implementing…

### DIFF
--- a/src/main/kotlin/coverosR3z/timerecording/EnterTimeAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/EnterTimeAPI.kt
@@ -1,10 +1,9 @@
-package coverosR3z.authentication
+package coverosR3z.timerecording
 
 import coverosR3z.domainobjects.*
 import coverosR3z.misc.safeHtml
 import coverosR3z.misc.successHTML
 import coverosR3z.server.*
-import coverosR3z.timerecording.ITimeRecordingUtilities
 
 enum class EnterTimeElements (val elemName: String, val id: String) {
     PROJECT_INPUT("project_entry", "project_entry"),

--- a/src/test/kotlin/coverosR3z/timerecording/EnterTimeAPITests.kt
+++ b/src/test/kotlin/coverosR3z/timerecording/EnterTimeAPITests.kt
@@ -36,7 +36,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_missingProject() {
         val data = mapOf(EnterTimeElements.TIME_INPUT.elemName to "60", EnterTimeElements.DETAIL_INPUT.elemName to "not much to say")
-        val ex = assertThrows(IllegalStateException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalStateException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals(projectIdNotNullMsg, ex.message)
     }
 
@@ -46,7 +46,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_missingTimeEntry() {
         val data = mapOf(EnterTimeElements.PROJECT_INPUT.elemName to "1", EnterTimeElements.DETAIL_INPUT.elemName to "not much to say")
-        val ex = assertThrows(IllegalStateException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalStateException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals(timeNotNullMsg, ex.message)
     }
 
@@ -56,7 +56,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_missingDetailEntry() {
         val data = mapOf(EnterTimeElements.PROJECT_INPUT.elemName to "1", EnterTimeElements.TIME_INPUT.elemName to "60")
-        val ex = assertThrows(IllegalStateException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalStateException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals(detailsNotNullMsg, ex.message)
     }
 
@@ -88,7 +88,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_nonNumericProject() {
         val data = mapOf(EnterTimeElements.PROJECT_INPUT.elemName to "aaaaa", EnterTimeElements.TIME_INPUT.elemName to "60", EnterTimeElements.DETAIL_INPUT.elemName to "not much to say")
-        val ex = assertThrows(IllegalStateException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalStateException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals("Must be able to parse aaaaa as integer", ex.message)
     }
 
@@ -98,7 +98,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_negativeProject() {
         val data = mapOf(EnterTimeElements.PROJECT_INPUT.elemName to "-1", EnterTimeElements.TIME_INPUT.elemName to "60", EnterTimeElements.DETAIL_INPUT.elemName to "not much to say")
-        val ex = assertThrows(IllegalArgumentException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalArgumentException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals("Valid identifier values are 1 or above", ex.message)
     }
 
@@ -108,7 +108,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_zeroProject() {
         val data = mapOf(EnterTimeElements.PROJECT_INPUT.elemName to "0", EnterTimeElements.TIME_INPUT.elemName to "60", EnterTimeElements.DETAIL_INPUT.elemName to "not much to say")
-        val ex = assertThrows(IllegalArgumentException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalArgumentException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals("Valid identifier values are 1 or above", ex.message)
     }
 
@@ -118,7 +118,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_aboveMaxProject() {
         val data = mapOf(EnterTimeElements.PROJECT_INPUT.elemName to (maximumProjectsCount+1).toString(), EnterTimeElements.TIME_INPUT.elemName to "60", EnterTimeElements.DETAIL_INPUT.elemName to "not much to say")
-        val ex = assertThrows(IllegalArgumentException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalArgumentException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals("No project id allowed over $maximumProjectsCount", ex.message)
     }
 
@@ -129,7 +129,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_aboveMaxTime() {
         val data = mapOf(EnterTimeElements.PROJECT_INPUT.elemName to "1", EnterTimeElements.TIME_INPUT.elemName to ((60*60*24)+1).toString(), EnterTimeElements.DETAIL_INPUT.elemName to "not much to say")
-        val ex = assertThrows(IllegalArgumentException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalArgumentException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals("${lessThanTimeInDayMsg}86401", ex.message)
     }
 
@@ -139,7 +139,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_negativeTime() {
         val data = mapOf(EnterTimeElements.PROJECT_INPUT.elemName to "1", EnterTimeElements.TIME_INPUT.elemName to "-60", EnterTimeElements.DETAIL_INPUT.elemName to "not much to say")
-        val ex = assertThrows(IllegalArgumentException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalArgumentException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals("${noNegativeTimeMsg}-60", ex.message)
     }
 
@@ -159,7 +159,7 @@ class EnterTimeAPITests {
     @Test
     fun testHandlePOSTTimeEntry_nonNumericTime() {
         val data = mapOf(EnterTimeElements.PROJECT_INPUT.elemName to "1", EnterTimeElements.TIME_INPUT.elemName to "aaa", EnterTimeElements.DETAIL_INPUT.elemName to "not much to say")
-        val ex = assertThrows(IllegalStateException::class.java){handlePOSTTimeEntry(tru, DEFAULT_USER,data)}
+        val ex = assertThrows(IllegalStateException::class.java){ handlePOSTTimeEntry(tru, DEFAULT_USER,data) }
         assertEquals("Must be able to parse aaa as integer", ex.message)
     }
 

--- a/src/test/kotlin/coverosR3z/uitests/BrowserSmokeTests.kt
+++ b/src/test/kotlin/coverosR3z/uitests/BrowserSmokeTests.kt
@@ -2,7 +2,7 @@ package coverosR3z.uitests
 
 import com.gargoylesoftware.htmlunit.BrowserVersion.BEST_SUPPORTED
 import coverosR3z.DEFAULT_USER
-import coverosR3z.authentication.EnterTimeElements
+import coverosR3z.timerecording.EnterTimeElements
 import coverosR3z.authentication.LoginElements
 import coverosR3z.logging.LogTypes
 import coverosR3z.logging.logSettings


### PR DESCRIPTION
… BDD scenario

Scenario is recording time on a different day than the present through the API

Co-authored-by: Jenna Charlton <jenna.charlton@coveros.com>
Co-authored-by: Byron Katz <byron.katz@coveros.com>
Co-authored-by: Mitch Hardee <mitchell.hardee@coveros.com>