### PR TITLE
Update runtime options logic.

### DIFF
--- a/src/main/kotlin/coverosR3z/Main.kt
+++ b/src/main/kotlin/coverosR3z/Main.kt
@@ -1,5 +1,6 @@
 package coverosR3z
 
+import coverosR3z.exceptions.ServerOptionsException
 import coverosR3z.logging.logStart
 import coverosR3z.server.Server
 import coverosR3z.server.Server.Companion.extractOptions
@@ -9,9 +10,13 @@ import coverosR3z.server.Server.Companion.extractOptions
  * argument is the port
  */
 fun main(args: Array<String>) {
-    val serverOptions = extractOptions(args)
-    logStart("starting server on port ${serverOptions.port}")
-    logStart("database directory is ${serverOptions.dbDirectory}")
-    Server(serverOptions.port, serverOptions.dbDirectory).startServer()
+    try {
+        val serverOptions = extractOptions(args)
+        logStart("starting server on port ${serverOptions.port}")
+        logStart("database directory is ${serverOptions.dbDirectory}")
+        Server(serverOptions.port, serverOptions.dbDirectory).startServer()
+    } catch (ex : ServerOptionsException) {
+        println(ex.message)
+    }
 }
 

--- a/src/main/kotlin/coverosR3z/server/Server.kt
+++ b/src/main/kotlin/coverosR3z/server/Server.kt
@@ -6,7 +6,9 @@ import coverosR3z.authentication.CurrentUser
 import coverosR3z.authentication.IAuthenticationUtilities
 import coverosR3z.domainobjects.DateTime
 import coverosR3z.domainobjects.SYSTEM_USER
+import coverosR3z.exceptions.ServerOptionsException
 import coverosR3z.logging.*
+import coverosR3z.misc.checkParseToInt
 import coverosR3z.persistence.PureMemoryDatabase
 import coverosR3z.timerecording.ITimeRecordingUtilities
 import coverosR3z.timerecording.TimeEntryPersistence
@@ -64,17 +66,91 @@ class Server(val port: Int, private val dbDirectory: String? = null) {
 
         lateinit var halfOpenServerSocket : ServerSocket
 
+        fun validatePort(arg : String, fullInput : String) {
+            val portNum = checkParseToInt(arg, {"Port number must be an integer value."})
+            if(portNum !in 1..65535) throw ServerOptionsException("port number was out of range.  Range is 1-65535.  Your input was: $fullInput")
+        }
+        fun validateDir(arg : String) : Boolean{
+            return !(arg.startsWith("-p") || arg=="--no-disk-persistence")
+        }
+
         /**
          * Given the command-line arguments, returns the first value
          * as an integer for use as a port number, or defaults to 12345
          */
-        fun extractOptions(args: Array<String>): ServerOptions {
+        fun extractOptions(args: Array<String>) : ServerOptions {
+
+            try {
+                return processArgs(args)
+            }
+            catch (ex: Throwable) {
+                throw ServerOptionsException(ex.message ?: "None")
+            }
+        }
+
+        private fun processArgs(args: Array<String>): ServerOptions {
+            val fullInput = args.joinToString(" ")
             return if (args.isEmpty() || args[0].isBlank()) {
                 ServerOptions()
             } else {
-                ServerOptions(port = args[0].toIntOrNull() ?: 12345)
+                //first boolean in each Pair indicates whether the flag is specified
+                var port = Pair<Boolean, Int?>(false, null)
+                var db = Pair<Boolean, String?>(false, null)
+                var ndp = Pair<Boolean, Boolean?>(false, null)
+
+                args.forEachIndexed { i, it ->
+
+                    if (it == "--no-disk-persistence") {
+                        if (ndp.first) throw ServerOptionsException("The disk persistence option was specified multiple times. This is not allowed, go to jail.")
+                        ndp = Pair(true, true)
+                    } else if (it.startsWith("-p")) {
+                        if (port.first) throw ServerOptionsException("Multiple port values were provided. This is not allowed, go to jail.")
+                        val portStr: String =
+                            when {
+                                it.length > 2 -> it.substring(2)
+                                i + 1 < args.size -> args[i + 1]
+                                else -> throw ServerOptionsException("The port option was specified, but no port number was given. This is dumb, you are dumb.")
+                            }
+                        validatePort(portStr, fullInput)
+                        port = Pair(true, portStr.toInt())
+                    } else if (it.startsWith("-d")) {
+                        if (db.first) throw ServerOptionsException("The database option was specified multiple times. This is not allowed, go to jail.")
+                        val dbStr: String =
+                            when {
+                                it.length > 2 -> it.substring(2)
+                                i + 1 < args.size && validateDir(args[i + 1]) -> args[i + 1]
+                                else -> throw ServerOptionsException("The directory option was provided without a directory value")
+                            }
+                        db = Pair(true, dbStr)
+                    } else if (it.startsWith("-h")) {
+                        throw ServerOptionsException(fullHelpMessage)
+                    }
+                }
+
+                ServerOptions.make(port.second, db.second, ndp.second)
             }
         }
+
+        val fullHelpMessage = """
+Here is some help for running this application.
+        
+You can provide options when running this, to change its configuration.
+
+Sample: 
+    The following runs the application with the
+    port set to 54321 and the database directory
+    set to "db":
+    
+    java -jar r3z-1.2.jar -p 54321 -d db
+    
+The options available are:
+
+-h                     prints this help message
+-p PORT_NUMBER         set the port number for the server
+-d DIRECTORY           the directory to store data
+--no-disk-persistence  do not write data to the disk.  Note
+                       that this is primarily (exclusively?) for tesiing
+    """.trimIndent()
 
         fun handleRequest(server: ISocketWrapper, au: IAuthenticationUtilities, tru: ITimeRecordingUtilities) : AnalyzedHttpData {
             lateinit var analyzedHttpData : AnalyzedHttpData

--- a/src/main/kotlin/coverosR3z/server/ServerOptions.kt
+++ b/src/main/kotlin/coverosR3z/server/ServerOptions.kt
@@ -4,10 +4,20 @@ data class ServerOptions(
         /**
          * The port the server will use
          */
-        val port : Int = 12345,
+        val port : Int = defaultPort,
         /**
          * the directory in which we will store the data
          * if this is set to null, we won't store anything to disk,
          * which is really just useful for testing
          */
-        val dbDirectory : String? = "db")
+        val dbDirectory : String? = "db"){
+        companion object{
+                const val defaultPort = 12345
+                fun make(port : Int?, dbDirectory : String?, ndp : Boolean?) : ServerOptions{
+                        val makePort = port ?: defaultPort
+                        check(!(dbDirectory!=null && ndp==true)){"If you're setting the noDiskPersistence option and also a database directory, you're very foolish."}
+                        val makeDBDir = if(ndp==true) null else dbDirectory
+                        return ServerOptions(makePort, makeDBDir)
+                }
+        }
+}

--- a/src/test/kotlin/coverosR3z/MainTests.kt
+++ b/src/test/kotlin/coverosR3z/MainTests.kt
@@ -37,7 +37,19 @@ class MainTests {
      */
     @Test
     fun testMain() {
-        val data = arrayOf("-p 54321")
+        val data = arrayOf("-p","54321")
+
+        // first thread starts the server
+        thread{main(data)}
+    }
+
+    /**
+     * If we run main with a particular port number,
+     * it should indicate that during startup
+     */
+    @Test
+    fun testMain_GetHelp() {
+        val data = arrayOf("-h")
 
         // first thread starts the server
         thread{main(data)}

--- a/src/test/kotlin/coverosR3z/uitests/UITests.kt
+++ b/src/test/kotlin/coverosR3z/uitests/UITests.kt
@@ -12,9 +12,7 @@ import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
 import org.openqa.selenium.WebDriver
-import java.io.File
 import kotlin.concurrent.thread
-
 
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)

--- a/src/test/kotlin/coverosR3z/uitests/UITestsBDD.kt
+++ b/src/test/kotlin/coverosR3z/uitests/UITestsBDD.kt
@@ -14,7 +14,6 @@ import org.junit.runners.MethodSorters
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeDriver
-import java.io.File
 import kotlin.concurrent.thread
 
 /**


### PR DESCRIPTION
Fixing some tests - may not need disk persistence.
Improving server options validation and parsing.
Including help option

Co-authored-by: Matt Taylor <matthew.taylor@coveros.com>
Co-authored-by: Mitch Hardee <mitchell.hardee@coveros.com>
Co-authored-by: Byron Katz <byron.katz@coveros.com>