### PR TITLE
improved redirect

### DIFF
--- a/docs/performance_archive/granular_tests/PERFORMANCE_should_get_responses_from_the_database_quickly
+++ b/docs/performance_archive/granular_tests/PERFORMANCE_should_get_responses_from_the_database_quickly
@@ -52,3 +52,4 @@
 2021-01-26	numberOfEmployees: 30	numberProjects: 30	numberOfDays: 31	time: 56
 2021-01-27	numberOfEmployees: 30	numberProjects: 30	numberOfDays: 31	time: 76
 2021-01-27	numberOfEmployees: 30	numberProjects: 30	numberOfDays: 31	time: 148
+2021-01-27	numberOfEmployees: 30	numberProjects: 30	numberOfDays: 31	time: 244

--- a/docs/performance_archive/granular_tests/testShouldWriteAndReadToDisk_PERFORMANCE
+++ b/docs/performance_archive/granular_tests/testShouldWriteAndReadToDisk_PERFORMANCE
@@ -45,3 +45,4 @@
 2021-01-26	numberOfEmployees: 20	numberOfProjects: 10	numberOfDays: 31	totalTime: 4496
 2021-01-27	numberOfEmployees: 20	numberOfProjects: 10	numberOfDays: 31	totalTime: 3098
 2021-01-27	numberOfEmployees: 20	numberOfProjects: 10	numberOfDays: 31	totalTime: 4466
+2021-01-27	numberOfEmployees: 20	numberOfProjects: 10	numberOfDays: 31	totalTime: 3564

--- a/docs/performance_archive/granular_tests/testWithValidClient_LoginPage_PERFORMANCE
+++ b/docs/performance_archive/granular_tests/testWithValidClient_LoginPage_PERFORMANCE
@@ -43,3 +43,4 @@
 2021-01-26	numberOfRequests: 100	time: 49
 2021-01-27	numberOfRequests: 100	time: 35
 2021-01-27	numberOfRequests: 100	time: 73
+2021-01-27	numberOfRequests: 100	time: 118

--- a/src/main/kotlin/coverosR3z/timerecording/api/EnterTimeAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/api/EnterTimeAPI.kt
@@ -6,6 +6,7 @@ import coverosR3z.server.types.*
 import coverosR3z.server.utility.AuthUtilities.Companion.doGETRequireAuth
 import coverosR3z.server.utility.AuthUtilities.Companion.doPOSTAuthenticated
 import coverosR3z.server.utility.ServerUtilities.Companion.okHTML
+import coverosR3z.server.utility.ServerUtilities.Companion.redirectTo
 import coverosR3z.server.utility.successHTML
 import coverosR3z.timerecording.types.*
 
@@ -77,7 +78,7 @@ class EnterTimeAPI(private val sd: ServerData) {
 
         tru.recordTime(timeEntry)
 
-        return okHTML(successHTML)
+        return redirectTo(ViewTimeAPI.path)
     }
 
 

--- a/src/main/kotlin/coverosR3z/timerecording/api/ViewTimeAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/api/ViewTimeAPI.kt
@@ -14,6 +14,7 @@ class ViewTimeAPI(private val sd: ServerData) {
 
     enum class Elements (private val elemName: String = "", private val id: String = "", private val elemClass: String = "") : Element {
         PROJECT_INPUT("project_entry", "project_entry"),
+        CREATE_TIME_ENTRY_ROW(id="create_time_entry"),
         TIME_INPUT("time_entry", "time_entry"),
         DETAIL_INPUT("detail_entry", "detail_entry"),
         EDIT_BUTTON(elemClass = "editbutton"),
@@ -176,7 +177,7 @@ class ViewTimeAPI(private val sd: ServerData) {
                           """
 
     private fun renderCreateTimeRow(projects: List<Project>) = """
-                        <tr id="create-time-entry">
+                        <tr id="${Elements.CREATE_TIME_ENTRY_ROW.getId()}">
                             <form action="${EnterTimeAPI.path}" method="post">
                                 <td class="project">
                                     <select name="project_entry" id="project_entry"/>

--- a/src/test/kotlin/coverosR3z/timerecording/EnterTimeAPITests.kt
+++ b/src/test/kotlin/coverosR3z/timerecording/EnterTimeAPITests.kt
@@ -13,10 +13,7 @@ import coverosR3z.misc.utility.getTime
 import coverosR3z.misc.utility.toStr
 import coverosR3z.persistence.utility.PureMemoryDatabase
 import coverosR3z.server.ServerPerformanceTests
-import coverosR3z.server.types.AnalyzedHttpData
-import coverosR3z.server.types.AuthStatus
-import coverosR3z.server.types.PostBodyData
-import coverosR3z.server.types.ServerData
+import coverosR3z.server.types.*
 import coverosR3z.timerecording.api.EnterTimeAPI
 import coverosR3z.timerecording.persistence.TimeEntryPersistence
 import coverosR3z.timerecording.types.*
@@ -49,8 +46,11 @@ class EnterTimeAPITests {
                 EnterTimeAPI.Elements.DATE_INPUT.getElemName() to DEFAULT_DATE_STRING
         ))
         val sd = ServerData(au, tru, AnalyzedHttpData(data = data), authStatus = AuthStatus.AUTHENTICATED)
-        val response = EnterTimeAPI.handlePost(sd).fileContents
-        assertTrue("we should have gotten the success page.  Got: $response", toStr(response).contains("SUCCESS"))
+        val result = EnterTimeAPI.handlePost(sd)
+
+        // this should cause a redirect back to the timeentries page
+        assertEquals(StatusCode.SEE_OTHER, result.statusCode)
+        assertTrue(result.headers.contains("Location: timeentries"))
     }
 
     /**
@@ -213,8 +213,11 @@ class EnterTimeAPITests {
                 EnterTimeAPI.Elements.DATE_INPUT.getElemName() to DEFAULT_DATE_STRING
         ))
         val sd = ServerData(au, tru, AnalyzedHttpData(data = data), authStatus = AuthStatus.AUTHENTICATED)
-        val result = EnterTimeAPI.handlePost(sd).fileContents
-        assertTrue("we should have gotten the success page.  Got: $result", toStr(result).contains("SUCCESS"))
+        val result = EnterTimeAPI.handlePost(sd)
+
+        // this should cause a redirect back to the timeentries page
+        assertEquals(StatusCode.SEE_OTHER, result.statusCode)
+        assertTrue(result.headers.contains("Location: timeentries"))
     }
 
     /**
@@ -292,11 +295,11 @@ class EnterTimeAPITests {
                 ))
 
                 val sd = ServerData(au, tru, AnalyzedHttpData(data = data), authStatus = AuthStatus.AUTHENTICATED)
-                val response = EnterTimeAPI.handlePost(sd).fileContents
-                assertTrue(
-                    "we should have gotten the success page.  Got: $response",
-                    toStr(response).contains("SUCCESS")
-                )
+                val response = EnterTimeAPI.handlePost(sd)
+                // this should cause a redirect back to the timeentries page
+                assertEquals(StatusCode.SEE_OTHER, response.statusCode)
+                assertTrue(response.headers.contains("Location: timeentries"))
+
             }
         }
         resetLogSettingsToDefault()

--- a/src/test/kotlin/coverosR3z/timerecording/EnterTimeAPITests.kt
+++ b/src/test/kotlin/coverosR3z/timerecording/EnterTimeAPITests.kt
@@ -48,10 +48,9 @@ class EnterTimeAPITests {
         val sd = ServerData(au, tru, AnalyzedHttpData(data = data), authStatus = AuthStatus.AUTHENTICATED)
         val result = EnterTimeAPI.handlePost(sd)
 
-        // this should cause a redirect back to the timeentries page
-        assertEquals(StatusCode.SEE_OTHER, result.statusCode)
-        assertTrue(result.headers.contains("Location: timeentries"))
+        assertSuccessfulTimeEntry(result)
     }
+
 
     /**
      * If we are missing required data
@@ -215,9 +214,7 @@ class EnterTimeAPITests {
         val sd = ServerData(au, tru, AnalyzedHttpData(data = data), authStatus = AuthStatus.AUTHENTICATED)
         val result = EnterTimeAPI.handlePost(sd)
 
-        // this should cause a redirect back to the timeentries page
-        assertEquals(StatusCode.SEE_OTHER, result.statusCode)
-        assertTrue(result.headers.contains("Location: timeentries"))
+        assertSuccessfulTimeEntry(result)
     }
 
     /**
@@ -295,10 +292,9 @@ class EnterTimeAPITests {
                 ))
 
                 val sd = ServerData(au, tru, AnalyzedHttpData(data = data), authStatus = AuthStatus.AUTHENTICATED)
-                val response = EnterTimeAPI.handlePost(sd)
-                // this should cause a redirect back to the timeentries page
-                assertEquals(StatusCode.SEE_OTHER, response.statusCode)
-                assertTrue(response.headers.contains("Location: timeentries"))
+                val result = EnterTimeAPI.handlePost(sd)
+
+                assertSuccessfulTimeEntry(result)
 
             }
         }
@@ -316,5 +312,14 @@ class EnterTimeAPITests {
                  |_|
      alt-text: Helper Methods
      */
+
+
+    /**
+     * this should confirm what happens when a user successfully enters their time
+     */
+    private fun assertSuccessfulTimeEntry(result: PreparedResponseData) {
+        assertEquals(StatusCode.SEE_OTHER, result.statusCode)
+        assertTrue(result.headers.contains("Location: timeentries"))
+    }
 
 }

--- a/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
+++ b/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
@@ -8,6 +8,7 @@ import coverosR3z.logging.LoggingAPI
 import coverosR3z.timerecording.api.CreateEmployeeAPI
 import coverosR3z.timerecording.api.EnterTimeAPI
 import coverosR3z.timerecording.api.ProjectAPI
+import org.junit.Assert.assertEquals
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeDriver
@@ -28,6 +29,7 @@ class EnterTimePage(private val driver: WebDriver, private val domain : String) 
         driver.findElement(By.id(EnterTimeAPI.Elements.DETAIL_INPUT.getId())).sendKeys(details)
         driver.findElement(By.id(EnterTimeAPI.Elements.DATE_INPUT.getId())).sendKeys(date)
         driver.findElement(By.id(EnterTimeAPI.Elements.ENTER_TIME_BUTTON.getId())).click()
+        assertEquals("your time entries" ,driver.title)
     }
 }
 

--- a/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
+++ b/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
@@ -26,10 +26,11 @@ class EnterTimePage(private val driver: WebDriver, private val domain : String) 
     fun enterTime(project: String, time: String, details: String, date: String) {
         driver.get("$domain/${ViewTimeAPI.path}")
         driver.findElement(By.id(ViewTimeAPI.Elements.PROJECT_INPUT.getId())).findElement(By.xpath("//option[. = '$project']")).click()
-        driver.findElement(By.id(ViewTimeAPI.Elements.TIME_INPUT.getId())).sendKeys(time)
-        driver.findElement(By.id(ViewTimeAPI.Elements.DETAIL_INPUT.getId())).sendKeys(details)
-        driver.findElement(By.id(ViewTimeAPI.Elements.DATE_INPUT.getId())).sendKeys(date)
-        driver.findElement(By.id(ViewTimeAPI.Elements.SAVE_BUTTON.getId())).click()
+        val createContainer = driver.findElement(By.id(ViewTimeAPI.Elements.CREATE_TIME_ENTRY_ROW.getId()))
+        createContainer.findElement(By.name(ViewTimeAPI.Elements.TIME_INPUT.getElemName())).sendKeys(time)
+        createContainer.findElement(By.name(ViewTimeAPI.Elements.DETAIL_INPUT.getElemName())).sendKeys(details)
+        createContainer.findElement(By.name(ViewTimeAPI.Elements.DATE_INPUT.getElemName())).sendKeys(date)
+        createContainer.findElement(By.className(ViewTimeAPI.Elements.SAVE_BUTTON.getElemClass())).click()
         assertEquals("your time entries" ,driver.title)
     }
 }

--- a/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
+++ b/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
@@ -31,6 +31,7 @@ class EnterTimePage(private val driver: WebDriver, private val domain : String) 
         createContainer.findElement(By.name(ViewTimeAPI.Elements.DETAIL_INPUT.getElemName())).sendKeys(details)
         createContainer.findElement(By.name(ViewTimeAPI.Elements.DATE_INPUT.getElemName())).sendKeys(date)
         createContainer.findElement(By.className(ViewTimeAPI.Elements.SAVE_BUTTON.getElemClass())).click()
+        // we verify the time entry is registered later, so only need to test that we end up on the right page successfully
         assertEquals("your time entries" ,driver.title)
     }
 }

--- a/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
+++ b/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
@@ -32,7 +32,7 @@ class EnterTimePage(private val driver: WebDriver, private val domain : String) 
         createContainer.findElement(By.name(ViewTimeAPI.Elements.DATE_INPUT.getElemName())).sendKeys(date)
         createContainer.findElement(By.className(ViewTimeAPI.Elements.SAVE_BUTTON.getElemClass())).click()
         // we verify the time entry is registered later, so only need to test that we end up on the right page successfully
-        assertEquals("your time entries" ,driver.title)
+        assertEquals("your time entries", driver.title)
     }
 }
 

--- a/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
+++ b/src/test/kotlin/coverosR3z/uitests/UITestHelpers.kt
@@ -8,6 +8,7 @@ import coverosR3z.logging.LoggingAPI
 import coverosR3z.timerecording.api.CreateEmployeeAPI
 import coverosR3z.timerecording.api.EnterTimeAPI
 import coverosR3z.timerecording.api.ProjectAPI
+import coverosR3z.timerecording.api.ViewTimeAPI
 import org.junit.Assert.assertEquals
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
@@ -23,12 +24,12 @@ enum class Drivers(val driver: () -> WebDriver){
 class EnterTimePage(private val driver: WebDriver, private val domain : String) {
 
     fun enterTime(project: String, time: String, details: String, date: String) {
-        driver.get("$domain/${EnterTimeAPI.path}")
-        driver.findElement(By.id(EnterTimeAPI.Elements.PROJECT_INPUT.getId())).findElement(By.xpath("//option[. = '$project']")).click()
-        driver.findElement(By.id(EnterTimeAPI.Elements.TIME_INPUT.getId())).sendKeys(time)
-        driver.findElement(By.id(EnterTimeAPI.Elements.DETAIL_INPUT.getId())).sendKeys(details)
-        driver.findElement(By.id(EnterTimeAPI.Elements.DATE_INPUT.getId())).sendKeys(date)
-        driver.findElement(By.id(EnterTimeAPI.Elements.ENTER_TIME_BUTTON.getId())).click()
+        driver.get("$domain/${ViewTimeAPI.path}")
+        driver.findElement(By.id(ViewTimeAPI.Elements.PROJECT_INPUT.getId())).findElement(By.xpath("//option[. = '$project']")).click()
+        driver.findElement(By.id(ViewTimeAPI.Elements.TIME_INPUT.getId())).sendKeys(time)
+        driver.findElement(By.id(ViewTimeAPI.Elements.DETAIL_INPUT.getId())).sendKeys(details)
+        driver.findElement(By.id(ViewTimeAPI.Elements.DATE_INPUT.getId())).sendKeys(date)
+        driver.findElement(By.id(ViewTimeAPI.Elements.SAVE_BUTTON.getId())).click()
         assertEquals("your time entries" ,driver.title)
     }
 }


### PR DESCRIPTION
This PR begins pointing time entry operations to the viewTimes page, where all time entry activity is moving