### PR TITLE
Changing how we check roles in APIs

### DIFF
--- a/src/main/kotlin/coverosR3z/authentication/api/LoginAPI.kt
+++ b/src/main/kotlin/coverosR3z/authentication/api/LoginAPI.kt
@@ -2,7 +2,6 @@ package coverosR3z.authentication.api
 
 import coverosR3z.authentication.types.*
 import coverosR3z.authentication.utility.IAuthenticationUtilities
-import coverosR3z.authentication.utility.RolesChecker
 import coverosR3z.server.api.HomepageAPI
 import coverosR3z.server.api.handleUnauthorized
 import coverosR3z.server.types.*
@@ -41,14 +40,13 @@ class LoginAPI(val sd: ServerData) {
 
         override fun handleGet(sd: ServerData): PreparedResponseData {
             val l = LoginAPI(sd)
-            return doGETRequireUnauthenticated(sd.authStatus)
+            return doGETRequireUnauthenticated(sd.ahd.user)
             { PageComponents.makeTemplate("login page", "LoginAPI", l.loginHTML, extraHeaderContent="""<link rel="stylesheet" href="loginpage.css" />""")}
         }
 
         override fun handlePost(sd: ServerData): PreparedResponseData {
-            RolesChecker(CurrentUser(sd.ahd.user)).checkAllowed(Roles.NONE)
             val l = LoginAPI(sd)
-            return doPOSTRequireUnauthenticated(sd.authStatus, requiredInputs, sd.ahd.data) { l.handlePOST() }
+            return doPOSTRequireUnauthenticated(sd.ahd.user, requiredInputs, sd.ahd.data) { l.handlePOST() }
         }
     }
 

--- a/src/main/kotlin/coverosR3z/authentication/api/LogoutAPI.kt
+++ b/src/main/kotlin/coverosR3z/authentication/api/LogoutAPI.kt
@@ -1,5 +1,6 @@
 package coverosR3z.authentication.api
 
+import coverosR3z.authentication.types.Roles
 import coverosR3z.server.types.GetEndpoint
 import coverosR3z.server.types.PreparedResponseData
 import coverosR3z.server.types.ServerData
@@ -12,7 +13,7 @@ class LogoutAPI(private val sd: ServerData) {
 
         override fun handleGet(sd: ServerData): PreparedResponseData {
             val l = LogoutAPI(sd)
-            return doGETRequireAuth(sd.authStatus) { l.generateLogoutPage() }
+            return doGETRequireAuth(sd.ahd.user, Roles.ADMIN, Roles.APPROVER, Roles.REGULAR) { l.generateLogoutPage() }
         }
 
         override val path: String

--- a/src/main/kotlin/coverosR3z/authentication/api/RegisterAPI.kt
+++ b/src/main/kotlin/coverosR3z/authentication/api/RegisterAPI.kt
@@ -45,13 +45,12 @@ class RegisterAPI(private val sd: ServerData) {
 
         override fun handleGet(sd: ServerData): PreparedResponseData {
             val r = RegisterAPI(sd)
-            return doGETRequireUnauthenticated(sd.authStatus) { r.registerHTML() }
+            return doGETRequireUnauthenticated(sd.ahd.user) { r.registerHTML() }
         }
 
         override fun handlePost(sd: ServerData): PreparedResponseData {
-            RolesChecker(CurrentUser(sd.ahd.user)).checkAllowed(Roles.NONE)
             val r = RegisterAPI(sd)
-            return doPOSTRequireUnauthenticated(sd.authStatus, requiredInputs, sd.ahd.data) { r.handlePOST() }
+            return doPOSTRequireUnauthenticated(sd.ahd.user, requiredInputs, sd.ahd.data) { r.handlePOST() }
         }
     }
 

--- a/src/main/kotlin/coverosR3z/logging/LoggingAPI.kt
+++ b/src/main/kotlin/coverosR3z/logging/LoggingAPI.kt
@@ -48,15 +48,13 @@ class LoggingAPI(private val sd: ServerData) {
             get() = "logging"
 
         override fun handleGet(sd: ServerData): PreparedResponseData {
-            RolesChecker(CurrentUser(sd.ahd.user)).checkAllowed(Roles.ADMIN)
             val l = LoggingAPI(sd)
-            return doGETRequireAuth(sd.authStatus) { l.loggingConfigHtml() }
+            return doGETRequireAuth(sd.ahd.user, Roles.ADMIN) { l.loggingConfigHtml() }
         }
 
         override fun handlePost(sd: ServerData): PreparedResponseData {
-            RolesChecker(CurrentUser(sd.ahd.user)).checkAllowed(Roles.ADMIN)
             val l = LoggingAPI(sd)
-            return doPOSTAuthenticated(sd.authStatus, requiredInputs, sd.ahd.data) { l.handlePOST() }
+            return doPOSTAuthenticated(sd.ahd.user, requiredInputs, sd.ahd.data, Roles.ADMIN) { l.handlePOST() }
         }
 
     }

--- a/src/main/kotlin/coverosR3z/server/api/HomepageAPI.kt
+++ b/src/main/kotlin/coverosR3z/server/api/HomepageAPI.kt
@@ -15,8 +15,10 @@ class HomepageAPI(private val sd: ServerData)  {
 
         override fun handleGet(sd: ServerData) : PreparedResponseData {
             val hp = HomepageAPI(sd)
-            return doGETAuthAndUnauth(sd.authStatus, { hp.authHomePageHTML() },
-                { PageComponents.makeTemplate("Homepage", "HomepageAPI", hp.homepageHTML, extraHeaderContent="""<link rel="stylesheet" href="homepage.css" />""")  })
+            return doGETAuthAndUnauth(sd.ahd.user,
+                Roles.REGULAR, Roles.APPROVER, Roles.ADMIN,
+                generatorAuthenticated = { hp.authHomePageHTML() },
+                generatorUnauth = { PageComponents.makeTemplate("Homepage", "HomepageAPI", hp.homepageHTML, extraHeaderContent="""<link rel="stylesheet" href="homepage.css" />""")  })
         }
 
         override val path: String

--- a/src/main/kotlin/coverosR3z/timerecording/api/CreateEmployeeAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/api/CreateEmployeeAPI.kt
@@ -42,15 +42,13 @@ class CreateEmployeeAPI(private val sd: ServerData) {
             get() = "createemployee"
 
         override fun handleGet(sd: ServerData): PreparedResponseData {
-            RolesChecker(CurrentUser(sd.ahd.user)).checkAllowed(Roles.ADMIN)
             val ce = CreateEmployeeAPI(sd)
-            return doGETRequireAuth(sd.authStatus) { ce.createEmployeeHTML() }
+            return doGETRequireAuth(sd.ahd.user, Roles.ADMIN) { ce.createEmployeeHTML() }
         }
 
         override fun handlePost(sd: ServerData): PreparedResponseData {
-            RolesChecker(CurrentUser(sd.ahd.user)).checkAllowed(Roles.SYSTEM, Roles.ADMIN)
             val ce = CreateEmployeeAPI(sd)
-            return doPOSTAuthenticated(sd.authStatus, requiredInputs, sd.ahd.data) { ce.createEmployee() }
+            return doPOSTAuthenticated(sd.ahd.user, requiredInputs, sd.ahd.data, Roles.SYSTEM, Roles.ADMIN) { ce.createEmployee() }
         }
 
     }

--- a/src/main/kotlin/coverosR3z/timerecording/api/EnterTimeAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/api/EnterTimeAPI.kt
@@ -1,5 +1,8 @@
 package coverosR3z.timerecording.api
 
+import coverosR3z.authentication.types.CurrentUser
+import coverosR3z.authentication.types.Roles
+import coverosR3z.authentication.utility.RolesChecker
 import coverosR3z.misc.types.Date
 import coverosR3z.misc.utility.safeHtml
 import coverosR3z.server.types.*
@@ -44,12 +47,12 @@ class EnterTimeAPI(private val sd: ServerData) {
 
         override fun handleGet(sd: ServerData): PreparedResponseData {
             val et = EnterTimeAPI(sd)
-            return doGETRequireAuth(sd.authStatus) { et.entertimeHTML() }
+            return doGETRequireAuth(sd.ahd.user, Roles.REGULAR, Roles.APPROVER, Roles.ADMIN) { et.entertimeHTML() }
         }
 
         override fun handlePost(sd: ServerData): PreparedResponseData {
             val et = EnterTimeAPI(sd)
-            return doPOSTAuthenticated(sd.authStatus, requiredInputs, sd.ahd.data) { et.handlePOST() }
+            return doPOSTAuthenticated(sd.ahd.user, requiredInputs, sd.ahd.data, Roles.REGULAR, Roles.APPROVER, Roles.ADMIN) { et.handlePOST() }
         }
     }
 

--- a/src/main/kotlin/coverosR3z/timerecording/api/ProjectAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/api/ProjectAPI.kt
@@ -40,15 +40,13 @@ class ProjectAPI(private val sd: ServerData) {
             get() = "createproject"
 
         override fun handleGet(sd: ServerData): PreparedResponseData {
-            RolesChecker(CurrentUser(sd.ahd.user)).checkAllowed(Roles.ADMIN)
             val p = ProjectAPI(sd)
-            return doGETRequireAuth(sd.authStatus) { p.createProjectHTML() }
+            return doGETRequireAuth(sd.ahd.user, Roles.ADMIN) { p.createProjectHTML() }
         }
 
         override fun handlePost(sd: ServerData): PreparedResponseData {
-            RolesChecker(CurrentUser(sd.ahd.user)).checkAllowed(Roles.ADMIN)
             val p = ProjectAPI(sd)
-            return doPOSTAuthenticated(sd.authStatus, requiredInputs, sd.ahd.data) { p.handlePOST() }
+            return doPOSTAuthenticated(sd.ahd.user, requiredInputs, sd.ahd.data, Roles.ADMIN) { p.handlePOST() }
         }
 
 

--- a/src/main/kotlin/coverosR3z/timerecording/api/SubmitTimeAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/api/SubmitTimeAPI.kt
@@ -1,5 +1,6 @@
 package coverosR3z.timerecording.api
 
+import coverosR3z.authentication.types.Roles
 import coverosR3z.misc.types.Date
 import coverosR3z.server.types.*
 import coverosR3z.server.utility.AuthUtilities
@@ -38,9 +39,10 @@ class SubmitTimeAPI(private val sd: ServerData){
         override fun handlePost(sd: ServerData): PreparedResponseData {
             val st = SubmitTimeAPI(sd)
             return AuthUtilities.doPOSTAuthenticated(
-                sd.authStatus,
+                sd.ahd.user,
                 requiredInputs,
-                sd.ahd.data
+                sd.ahd.data,
+                Roles.REGULAR, Roles.APPROVER, Roles.ADMIN
             ) { st.handlePOST() }
         }
     }

--- a/src/main/kotlin/coverosR3z/timerecording/api/UnsubmitTimeAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/api/UnsubmitTimeAPI.kt
@@ -1,5 +1,6 @@
 package coverosR3z.timerecording.api
 
+import coverosR3z.authentication.types.Roles
 import coverosR3z.misc.types.Date
 import coverosR3z.server.types.*
 import coverosR3z.server.utility.AuthUtilities
@@ -38,9 +39,10 @@ class UnsubmitTimeAPI(private val sd: ServerData){
         override fun handlePost(sd: ServerData): PreparedResponseData {
             val st = UnsubmitTimeAPI(sd)
             return AuthUtilities.doPOSTAuthenticated(
-                sd.authStatus,
+                sd.ahd.user,
                 requiredInputs,
-                sd.ahd.data
+                sd.ahd.data,
+                Roles.REGULAR, Roles.APPROVER, Roles.ADMIN
             ) { st.handlePOST() }
         }
     }

--- a/src/main/kotlin/coverosR3z/timerecording/api/ViewEmployeesAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/api/ViewEmployeesAPI.kt
@@ -1,5 +1,6 @@
 package coverosR3z.timerecording.api
 
+import coverosR3z.authentication.types.Roles
 import coverosR3z.misc.utility.safeHtml
 import coverosR3z.server.types.GetEndpoint
 import coverosR3z.server.types.PreparedResponseData
@@ -12,7 +13,7 @@ class ViewEmployeesAPI(private val sd: ServerData) {
     companion object : GetEndpoint {
         override fun handleGet(sd: ServerData): PreparedResponseData {
             val ve = ViewEmployeesAPI(sd)
-            return doGETRequireAuth(sd.authStatus) { ve.existingEmployeesHTML() }
+            return doGETRequireAuth(sd.ahd.user, Roles.ADMIN) { ve.existingEmployeesHTML() }
         }
 
         override val path: String

--- a/src/main/kotlin/coverosR3z/timerecording/api/ViewTimeAPI.kt
+++ b/src/main/kotlin/coverosR3z/timerecording/api/ViewTimeAPI.kt
@@ -1,5 +1,6 @@
 package coverosR3z.timerecording.api
 
+import coverosR3z.authentication.types.Roles
 import coverosR3z.misc.types.Date
 import coverosR3z.misc.types.earliestAllowableDate
 import coverosR3z.misc.types.latestAllowableDate
@@ -58,15 +59,16 @@ class ViewTimeAPI(private val sd: ServerData) {
 
         override fun handleGet(sd: ServerData): PreparedResponseData {
             val vt = ViewTimeAPI(sd)
-            return doGETRequireAuth(sd.authStatus) { vt.existingTimeEntriesHTML() }
+            return doGETRequireAuth(sd.ahd.user, Roles.REGULAR, Roles.APPROVER, Roles.ADMIN) { vt.existingTimeEntriesHTML() }
         }
 
         override fun handlePost(sd: ServerData): PreparedResponseData {
             val vt = ViewTimeAPI(sd)
             return AuthUtilities.doPOSTAuthenticated(
-                sd.authStatus,
+                sd.ahd.user,
                 requiredInputs,
-                sd.ahd.data
+                sd.ahd.data,
+                Roles.REGULAR, Roles.APPROVER, Roles.ADMIN
             ) { vt.handlePOST() }
         }
 

--- a/src/test/kotlin/coverosR3z/server/ServerTests.kt
+++ b/src/test/kotlin/coverosR3z/server/ServerTests.kt
@@ -302,8 +302,7 @@ class ServerTests {
 
     /**
      * On some pages, like register and login, you are *supposed* to be
-     * unauthenticated to post to them.  If you *are* authenticated and
-     * post to those pages, you will receive a "forbidden" message
+     * unauthenticated to post to them.
      */
     @IntegrationTest(usesPort = true)
     @Category(IntegrationTestCategory::class)
@@ -318,7 +317,7 @@ class ServerTests {
 
         val result: AnalyzedHttpData = parseHttpMessage(client, FakeAuthenticationUtilities(), testLogger)
 
-        assertEquals(StatusCode.FORBIDDEN, result.statusCode)
+        assertEquals(StatusCode.SEE_OTHER, result.statusCode)
     }
 
     /**

--- a/src/test/kotlin/coverosR3z/timerecording/SubmitTimeAPITests.kt
+++ b/src/test/kotlin/coverosR3z/timerecording/SubmitTimeAPITests.kt
@@ -4,11 +4,7 @@ import coverosR3z.authentication.persistence.AuthenticationPersistence
 import coverosR3z.authentication.types.CurrentUser
 import coverosR3z.authentication.utility.AuthenticationUtilities
 import coverosR3z.authentication.utility.IAuthenticationUtilities
-import coverosR3z.fakeServerObjects
-import coverosR3z.misc.DEFAULT_USER
-import coverosR3z.misc.createEmptyDatabase
-import coverosR3z.misc.makeServerData
-import coverosR3z.misc.testLogger
+import coverosR3z.misc.*
 import coverosR3z.misc.types.Date
 import coverosR3z.server.APITestCategory
 import coverosR3z.server.types.*
@@ -48,7 +44,7 @@ class SubmitTimeAPITests {
             SubmitTimeAPI.Elements.START_DATE.getElemName() to startDate,
             SubmitTimeAPI.Elements.END_DATE.getElemName() to endDate,
         ))
-        val sd = makeServerData(data, tru, au)
+        val sd = makeSubmittingServerData(data)
 
         // the API processes the client input
         val response = SubmitTimeAPI.handlePost(sd).statusCode
@@ -64,6 +60,10 @@ class SubmitTimeAPITests {
             "We should have gotten redirected to the viewTime page",
             StatusCode.SEE_OTHER, response
         )
+    }
+
+    private fun makeSubmittingServerData(data: PostBodyData): ServerData {
+        return makeServerData(data, tru, au, user = DEFAULT_REGULAR_USER)
     }
 
 }

--- a/src/test/kotlin/coverosR3z/timerecording/ViewTimeAPITests.kt
+++ b/src/test/kotlin/coverosR3z/timerecording/ViewTimeAPITests.kt
@@ -1,11 +1,10 @@
 package coverosR3z.timerecording
 
 import coverosR3z.authentication.utility.FakeAuthenticationUtilities
-import coverosR3z.fakeServerObjects
 import coverosR3z.misc.DEFAULT_DATE_STRING
+import coverosR3z.misc.DEFAULT_REGULAR_USER
 import coverosR3z.misc.exceptions.InexactInputsException
 import coverosR3z.misc.makeServerData
-import coverosR3z.misc.testLogger
 import coverosR3z.server.APITestCategory
 import coverosR3z.server.types.*
 import coverosR3z.timerecording.api.ViewTimeAPI
@@ -38,7 +37,7 @@ class ViewTimeAPITests {
             Elements.DATE_INPUT.getElemName() to DEFAULT_DATE_STRING,
             Elements.ID_INPUT.getElemName() to "1"
         ))
-        val sd = makeServerData(data, tru, au)
+        val sd = makeVTServerData(data)
         val response = ViewTimeAPI.handlePost(sd).statusCode
         assertEquals(
             "We should have gotten redirected to the viewTime page",
@@ -55,7 +54,7 @@ class ViewTimeAPITests {
             Elements.DETAIL_INPUT.getElemName() to "not much to say",
             Elements.DATE_INPUT.getElemName() to DEFAULT_DATE_STRING,
         ))
-        val sd = makeServerData(data, tru, au)
+        val sd = makeVTServerData(data)
 
         val ex = assertThrows(InexactInputsException::class.java){ ViewTimeAPI.handlePost(sd) }
         assertEquals("expected keys: [${Elements.PROJECT_INPUT.getElemName()}, ${Elements.TIME_INPUT.getElemName()}, ${Elements.DETAIL_INPUT.getElemName()}, ${Elements.DATE_INPUT.getElemName()}, ${Elements.ID_INPUT.getElemName()}]. " +
@@ -71,7 +70,7 @@ class ViewTimeAPITests {
             Elements.DATE_INPUT.getElemName() to DEFAULT_DATE_STRING,
             Elements.ID_INPUT.getElemName() to "1"
         ))
-        val sd = makeServerData(data, tru, au)
+        val sd = makeVTServerData(data)
 
         val ex = assertThrows(InexactInputsException::class.java){ ViewTimeAPI.handlePost(sd) }
         assertEquals("expected keys: [${Elements.PROJECT_INPUT.getElemName()}, ${Elements.TIME_INPUT.getElemName()}, ${Elements.DETAIL_INPUT.getElemName()}, ${Elements.DATE_INPUT.getElemName()}, ${Elements.ID_INPUT.getElemName()}]. " +
@@ -87,7 +86,7 @@ class ViewTimeAPITests {
             Elements.DATE_INPUT.getElemName() to DEFAULT_DATE_STRING,
             Elements.ID_INPUT.getElemName() to "1"
         ))
-        val sd = makeServerData(data, tru, au)
+        val sd = makeVTServerData(data)
 
         val ex = assertThrows(InexactInputsException::class.java){ ViewTimeAPI.handlePost(sd) }
         assertEquals("expected keys: [${Elements.PROJECT_INPUT.getElemName()}, ${Elements.TIME_INPUT.getElemName()}, ${Elements.DETAIL_INPUT.getElemName()}, ${Elements.DATE_INPUT.getElemName()}, ${Elements.ID_INPUT.getElemName()}]. " +
@@ -103,7 +102,7 @@ class ViewTimeAPITests {
             Elements.DATE_INPUT.getElemName() to DEFAULT_DATE_STRING,
             Elements.ID_INPUT.getElemName() to "1"
         ))
-        val sd = makeServerData(data, tru, au)
+        val sd = makeVTServerData(data)
 
         val ex = assertThrows(InexactInputsException::class.java){ ViewTimeAPI.handlePost(sd) }
         assertEquals("expected keys: [${Elements.PROJECT_INPUT.getElemName()}, ${Elements.TIME_INPUT.getElemName()}, ${Elements.DETAIL_INPUT.getElemName()}, ${Elements.DATE_INPUT.getElemName()}, ${Elements.ID_INPUT.getElemName()}]. " +
@@ -119,11 +118,18 @@ class ViewTimeAPITests {
             Elements.DETAIL_INPUT.getElemName() to "not much to say",
             Elements.ID_INPUT.getElemName() to "1"
         ))
-        val sd = makeServerData(data, tru, au)
+        val sd = makeVTServerData(data)
 
         val ex = assertThrows(InexactInputsException::class.java){ ViewTimeAPI.handlePost(sd) }
         assertEquals("expected keys: [${Elements.PROJECT_INPUT.getElemName()}, ${Elements.TIME_INPUT.getElemName()}, ${Elements.DETAIL_INPUT.getElemName()}, ${Elements.DATE_INPUT.getElemName()}, ${Elements.ID_INPUT.getElemName()}]. " +
                 "received keys: [${Elements.PROJECT_INPUT.getElemName()}, ${Elements.TIME_INPUT.getElemName()}, ${Elements.DETAIL_INPUT.getElemName()}, ${Elements.ID_INPUT.getElemName()}]", ex.message)
+    }
+
+    /**
+     * Helper method to make a [ServerData] for the View time API tests
+     */
+    private fun makeVTServerData(data: PostBodyData): ServerData {
+        return makeServerData(data, tru, au, user = DEFAULT_REGULAR_USER)
     }
 
 }


### PR DESCRIPTION
Before, we were checking the roles and then letting the authentication utilities run.  That's silly.  We most often need to check whether they're even logged in first, before checking their roles.  Now that happens somewhat consistently.